### PR TITLE
bump rust-rdkafka 0.37.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs.git?rev=23dab15#23dab157cefe9d4e4fc30346b7d3d70c56cdf059"
+source = "git+https://github.com/drift-labs/drift-rs.git?rev=798bc05#798bc05e97948a1d4c851ec44a7d4cbbf352287e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs.git?rev=23dab15#23dab157cefe9d4e4fc30346b7d3d70c56cdf059"
+source = "git+https://github.com/drift-labs/drift-rs.git?rev=798bc05#798bc05e97948a1d4c851ec44a7d4cbbf352287e"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.15"
-source = "git+https://github.com/drift-labs/drift-rs.git?rev=23dab15#23dab157cefe9d4e4fc30346b7d3d70c56cdf059"
+source = "git+https://github.com/drift-labs/drift-rs.git?rev=798bc05#798bc05e97948a1d4c851ec44a7d4cbbf352287e"
 dependencies = [
  "abi_stable",
  "ahash 0.8.11",
@@ -3908,7 +3908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3928,7 +3928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -4135,9 +4135,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.36.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1beea247b9a7600a81d4cc33f659ce1a77e1988323d7d2809c7ed1c21f4c316d"
+checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ base64 = "0.22.1"
 clap = { version = "4.0", features = ["derive"] }
 dashmap = "6.1.0"
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs.git" , rev = "23dab15" }
+drift-rs = { git = "https://github.com/drift-labs/drift-rs.git" , rev = "798bc05" }
 ed25519-dalek = "1.0.1"
 env_logger = "0.11"
 faster-hex = "0.10.0"
@@ -33,7 +33,7 @@ log = "0.4.22"
 nanoid = "0.4.0"
 prometheus = "0.13"
 rand = "0.8"
-rdkafka = { version = "0.36.2", features = ["ssl", "sasl"] }
+rdkafka = { version = "0.37.0", features = ["ssl", "sasl"] }
 redis = { version = "0.29.1", features = ["tokio-comp", "tokio-native-tls-comp"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.127"


### PR DESCRIPTION
## changes

- use `producer.send_result`
should surface the error better has and less machinery vs.`.send`
also `producer.send` causing memory leaks: https://github.com/fede1024/rust-rdkafka/issues/746

- bump to v0.37.0: silent failure issue on consumer with v0.36.2: https://github.com/fede1024/rust-rdkafka/issues/638

- track kafka msg inflight count (sent but unackd)