### PR TITLE
pin github actions to commit shas

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # Common steps
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Install OS dependencies
         run: apt-get update && apt-get install -y git libssl-dev libsasl2-dev cmake jq
@@ -35,7 +35,7 @@ jobs:
           cp libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH
 
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/mainnet-beta.yml
+++ b/.github/workflows/mainnet-beta.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_PROD }}
@@ -19,7 +19,7 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
 
       - name: Install kubectl
         run: |
@@ -30,7 +30,7 @@ jobs:
           kubectl version --client=true
 
       - name: Docker build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: swift
@@ -48,14 +48,14 @@ jobs:
     needs: [build]
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_PROD }}
           aws-region: ${{ secrets.EKS_PROD_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3.2
         with:
           version: "v1.30.0"
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_NON_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_NON_PROD }}
@@ -19,7 +19,7 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
 
       - name: Install kubectl
         run: |
@@ -30,7 +30,7 @@ jobs:
           kubectl version --client=true
 
       - name: Docker build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: swift
@@ -48,14 +48,14 @@ jobs:
     needs: [build]
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_NON_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_NON_PROD }}
           aws-region: ${{ secrets.EKS_NON_PROD_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3.2
         with:
           version: "v1.30.0"
 

--- a/.github/workflows/restart-on-sdk-push.yml
+++ b/.github/workflows/restart-on-sdk-push.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_PROD }}
           aws-region: ${{ secrets.EKS_PROD_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3.2
         with:
           version: "v1.30.0"
 


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Actions across the four workflow files to commit SHAs, with the resolved version as a trailing comment.
- Replace the moving `aws-actions/configure-aws-credentials@master` reference with a pinned v4.3.1 commit so the workflow no longer follows that branch's HEAD.

Pinned versions:
- `actions/checkout` → v3.6.0
- `actions/cache` → v4.3.0
- `aws-actions/configure-aws-credentials` → v4.3.1 (was `@master`)
- `aws-actions/amazon-ecr-login` → v2.1.4
- `docker/build-push-action` → v6.19.2
- `azure/setup-kubectl` → v3.2

## Test plan
- [ ] CI runs `build-and-test` successfully on this PR
- [ ] After merge, `master` and `mainnet-beta` deploy workflows complete a build + deploy cycle without action-resolution errors