### PR TITLE
Build against protocol-v2-shadow master (decouple-amm)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,17 @@ on:
       - master
       - mainnet-beta
 
+defaults:
+  run:
+    working-directory: ./swift
+
+env:
+  # `drift-rs` and the `drift` crate (protocol-v2-shadow) are consumed as path
+  # deps on siblings of this repo (see Cargo.toml). These refs pin which
+  # commits CI builds against.
+  DRIFT_RS_REF: next
+  SHADOW_REF: master
+
 jobs:
   build_and_test:
     runs-on: ubicloud
@@ -16,8 +27,25 @@ jobs:
         task: ["build", "test"]
     steps:
       # Common steps
-      - name: Checkout main
+      - name: Checkout swift
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          path: swift
+
+      - name: Checkout drift-rs
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          repository: drift-labs/drift-rs
+          ref: ${{ env.DRIFT_RS_REF }}
+          path: drift-rs
+
+      - name: Checkout protocol-v2-shadow
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          repository: drift-labs/protocol-v2-shadow
+          ref: ${{ env.SHADOW_REF }}
+          token: ${{ secrets.GH_PAT }}
+          path: protocol-v2-shadow
 
       - name: Install OS dependencies
         run: apt-get update && apt-get install -y git libssl-dev

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,12 +39,21 @@ jobs:
           ref: ${{ env.DRIFT_RS_REF }}
           path: drift-rs
 
+      - name: Generate protocol-v2-shadow read token
+        id: shadow-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.VELOCITY_SDK_READER_APP_ID }}
+          private-key: ${{ secrets.VELOCITY_SDK_READER_PRIVATE_KEY }}
+          owner: drift-labs
+          repositories: protocol-v2-shadow
+
       - name: Checkout protocol-v2-shadow
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           repository: drift-labs/protocol-v2-shadow
           ref: ${{ env.SHADOW_REF }}
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.shadow-token.outputs.token }}
           path: protocol-v2-shadow
 
       - name: Install OS dependencies

--- a/.github/workflows/mainnet-beta.yml
+++ b/.github/workflows/mainnet-beta.yml
@@ -29,12 +29,21 @@ jobs:
           ref: ${{ env.DRIFT_RS_REF }}
           path: drift-rs
 
+      - name: Generate protocol-v2-shadow read token
+        id: shadow-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.VELOCITY_SDK_READER_APP_ID }}
+          private-key: ${{ secrets.VELOCITY_SDK_READER_PRIVATE_KEY }}
+          owner: drift-labs
+          repositories: protocol-v2-shadow
+
       - name: Checkout protocol-v2-shadow
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           repository: drift-labs/protocol-v2-shadow
           ref: ${{ env.SHADOW_REF }}
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.shadow-token.outputs.token }}
           path: protocol-v2-shadow
 
       - name: Configure AWS credentials

--- a/.github/workflows/mainnet-beta.yml
+++ b/.github/workflows/mainnet-beta.yml
@@ -7,12 +7,35 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  # drift-rs + protocol-v2-shadow (the `drift` crate) are path-dep siblings of
+  # swift; the docker build context is the parent dir holding all three.
+  DRIFT_RS_REF: next
+  SHADOW_REF: master
+
 jobs:
   build:
     runs-on: ubicloud
     steps:
-      - name: Checkout Code
+      - name: Checkout swift
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          path: swift
+
+      - name: Checkout drift-rs
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          repository: drift-labs/drift-rs
+          ref: ${{ env.DRIFT_RS_REF }}
+          path: drift-rs
+
+      - name: Checkout protocol-v2-shadow
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          repository: drift-labs/protocol-v2-shadow
+          ref: ${{ env.SHADOW_REF }}
+          token: ${{ secrets.GH_PAT }}
+          path: protocol-v2-shadow
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
@@ -42,6 +65,7 @@ jobs:
           BRANCH_NAME: ${{ github.ref_name }}
         with:
           context: .
+          file: swift/Dockerfile
           push: true
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}-${{ env.BRANCH_NAME }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,12 +29,21 @@ jobs:
           ref: ${{ env.DRIFT_RS_REF }}
           path: drift-rs
 
+      - name: Generate protocol-v2-shadow read token
+        id: shadow-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.VELOCITY_SDK_READER_APP_ID }}
+          private-key: ${{ secrets.VELOCITY_SDK_READER_PRIVATE_KEY }}
+          owner: drift-labs
+          repositories: protocol-v2-shadow
+
       - name: Checkout protocol-v2-shadow
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           repository: drift-labs/protocol-v2-shadow
           ref: ${{ env.SHADOW_REF }}
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.shadow-token.outputs.token }}
           path: protocol-v2-shadow
 
       - name: Configure AWS credentials

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,12 +7,35 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  # drift-rs + protocol-v2-shadow (the `drift` crate) are path-dep siblings of
+  # swift; the docker build context is the parent dir holding all three.
+  DRIFT_RS_REF: next
+  SHADOW_REF: master
+
 jobs:
   build:
     runs-on: ubicloud
     steps:
-      - name: Checkout Code
+      - name: Checkout swift
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          path: swift
+
+      - name: Checkout drift-rs
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          repository: drift-labs/drift-rs
+          ref: ${{ env.DRIFT_RS_REF }}
+          path: drift-rs
+
+      - name: Checkout protocol-v2-shadow
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          repository: drift-labs/protocol-v2-shadow
+          ref: ${{ env.SHADOW_REF }}
+          token: ${{ secrets.GH_PAT }}
+          path: protocol-v2-shadow
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
@@ -42,6 +65,7 @@ jobs:
           BRANCH_NAME: ${{ github.ref_name }}
         with:
           context: .
+          file: swift/Dockerfile
           push: true
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}-${{ env.BRANCH_NAME }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,7 +1438,6 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift"
 version = "2.162.0"
-source = "git+https://github.com/drift-labs/protocol-v2?rev=a0bdfea74bff46fae3f280acefed35f6b634dc67#a0bdfea74bff46fae3f280acefed35f6b634dc67"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1463,7 +1462,6 @@ dependencies = [
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs.git?rev=77a466c#77a466cd03e5c44b5d9a533afe16291b6047d311"
 dependencies = [
  "anchor-lang-idl",
  "proc-macro2",
@@ -1485,7 +1483,6 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs.git?rev=77a466c#77a466cd03e5c44b5d9a533afe16291b6047d311"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1507,7 +1504,6 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0"
-source = "git+https://github.com/drift-labs/drift-rs.git?rev=77a466c#77a466cd03e5c44b5d9a533afe16291b6047d311"
 dependencies = [
  "ahash 0.8.12",
  "anchor-lang",
@@ -3320,7 +3316,6 @@ checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 [[package]]
 name = "pyth_lazer"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2?rev=a0bdfea74bff46fae3f280acefed35f6b634dc67#a0bdfea74bff46fae3f280acefed35f6b634dc67"
 dependencies = [
  "anchor-lang",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ bincode = "1"
 clap = { version = "4.0", features = ["derive"] }
 dashmap = "6.1.0"
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs.git", rev = "77a466c" }
-drift = { git = "https://github.com/drift-labs/protocol-v2", rev = "a0bdfea74bff46fae3f280acefed35f6b634dc67", default-features = false, features = ["drift-rs", "mainnet-beta", "cpi"] }
+drift-rs = { path = "../drift-rs" }
+drift = { path = "../protocol-v2-shadow/programs/drift", default-features = false, features = ["drift-rs", "mainnet-beta", "cpi"] }
 solana-account-info = "3.1"
 solana-clock = "3"
 ed25519-dalek = "1.0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,21 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup component add rustfmt
 
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY src ./src
+# protocol-v2-shadow (the `drift` crate) and drift-rs are consumed as path-dep
+# siblings of swift. The build context is the parent dir holding all three; CI
+# checks them out side by side (see .github/workflows). Preserve the relative
+# layout so Cargo's `../drift-rs` / `../protocol-v2-shadow` paths resolve.
+COPY protocol-v2-shadow ./protocol-v2-shadow
+COPY drift-rs ./drift-rs
+COPY swift ./swift
 
+WORKDIR /app/swift
 RUN cargo build --release
 
 FROM amazonlinux:2023
 
 RUN yum install -y openssl
 
-COPY --from=builder /app/target/release/swift-server /usr/local/bin/swift-server
+COPY --from=builder /app/swift/target/release/swift-server /usr/local/bin/swift-server
 
 ENTRYPOINT ["/usr/local/bin/swift-server"]

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+# Ignore-file for swift/Dockerfile (BuildKit uses <dockerfile>.dockerignore in
+# preference to a context-root .dockerignore). Patterns are relative to the
+# build context root — the parent dir holding swift/, drift-rs/ and
+# protocol-v2-shadow/.
+**/target
+**/.git
+**/node_modules
+**/.DS_Store
+**/*.log

--- a/src/swift_server.rs
+++ b/src/swift_server.rs
@@ -282,7 +282,7 @@ pub async fn process_order(
 
     if let Err(err) = validate_signed_order_params(
         &order_params,
-        market.map(|m| m.amm.min_order_size).unwrap_or(0),
+        market.map(|m| m.market_stats.min_order_size).unwrap_or(0),
     ) {
         log::warn!(
             target: "server",


### PR DESCRIPTION
Builds swift against protocol-v2-shadow **master** (the merged decouple-amm refactor) instead of the old public protocol-v2 git deps.

## Changes
- `drift` / `drift-rs` consumed as local **path deps** (siblings), matching keep-rs / drift-vaults
- `swift_server.rs`: `min_order_size` is now on `PerpMarket.market_stats`
- CI (`build-and-test`, `master`, `mainnet-beta`) + `Dockerfile` check out `drift-rs@next` and `protocol-v2-shadow@master` as siblings via `GH_PAT`; the docker build context is the parent dir holding all three
- new `Dockerfile.dockerignore` keeps the (shadow-inclusive) build context lean

## Ref pins (workflow env)
`DRIFT_RS_REF: next`, `SHADOW_REF: master`

## Validation
Smoke-tested locally: full `cargo build --release` inside the image succeeds and the binary lands in the `amazonlinux:2023` runtime stage.

## Notes
- Requires `drift-rs@next` and `protocol-v2-shadow@master` to be current (both pushed)
- ⚠️ Merging to `master` triggers the non-prod build + EKS rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)