### PR TITLE
build against velocity (drift→velocity rebrand)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,30 +1436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "drift"
-version = "2.162.0"
-dependencies = [
- "anchor-lang",
- "anchor-spl",
- "arrayref",
- "base64 0.13.1",
- "borsh",
- "bytemuck",
- "byteorder",
- "drift-macros",
- "enumflags2",
- "hex",
- "num-integer",
- "num-traits",
- "pyth-client",
- "pyth_lazer",
- "solana-program",
- "solana-security-txt",
- "static_assertions",
- "uint",
-]
-
-[[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
 dependencies = [
@@ -1513,7 +1489,6 @@ dependencies = [
  "bytemuck",
  "crossbeam",
  "dashmap",
- "drift",
  "drift-idl-gen",
  "drift-pubsub-client",
  "env_logger",
@@ -1545,6 +1520,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.28.0",
+ "velocity",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",
 ]
@@ -5811,7 +5787,6 @@ dependencies = [
  "clap",
  "dashmap",
  "dotenv",
- "drift",
  "drift-rs",
  "ed25519-dalek 1.0.1",
  "env_logger",
@@ -5843,6 +5818,7 @@ dependencies = [
  "tower-http 0.6.10",
  "urlencoding",
  "uuid",
+ "velocity",
  "zstd",
 ]
 
@@ -6540,6 +6516,30 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "velocity"
+version = "2.162.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "arrayref",
+ "base64 0.13.1",
+ "borsh",
+ "bytemuck",
+ "byteorder",
+ "drift-macros",
+ "enumflags2",
+ "hex",
+ "num-integer",
+ "num-traits",
+ "pyth-client",
+ "pyth_lazer",
+ "solana-program",
+ "solana-security-txt",
+ "static_assertions",
+ "uint",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4.0", features = ["derive"] }
 dashmap = "6.1.0"
 dotenv = "0.15.0"
 drift-rs = { path = "../drift-rs" }
-drift = { path = "../protocol-v2-shadow/programs/drift", default-features = false, features = ["drift-rs", "mainnet-beta", "cpi"] }
+drift = { package = "velocity", path = "../protocol-v2-shadow/programs/velocity", default-features = false, features = ["velocity-rs", "mainnet-beta", "cpi"] }
 solana-account-info = "3.1"
 solana-clock = "3"
 ed25519-dalek = "1.0.1"

--- a/src/util/local_sim.rs
+++ b/src/util/local_sim.rs
@@ -16,8 +16,8 @@ use std::{
 use anchor_lang::AccountDeserialize;
 use drift::{
     controller::orders::place_perp_order,
-    error::{DriftResult, ErrorCode},
-    sdk::{DriftAccounts, OwnedAccount},
+    error::{VelocityResult, ErrorCode},
+    sdk::{VelocityAccounts, OwnedAccount},
     state::{
         oracle_map::OracleMap,
         order_params::{OrderParams, PlaceOrderOptions},
@@ -58,11 +58,11 @@ fn build_infos<'a>(entries: &'a mut [(Pubkey, OwnedAccount)]) -> Vec<AccountInfo
 /// `State` is Borsh-only and not safely castable from the Pod IDL mirror.
 pub fn simulate_place_perp_order(
     user: &User,
-    accounts: &mut DriftAccounts,
+    accounts: &mut VelocityAccounts,
     state_bytes: &[u8],
     order_params: OrderParams,
     max_margin_ratio: Option<u16>,
-) -> DriftResult<()> {
+) -> VelocityResult<()> {
     let state = NativeState::try_deserialize(&mut &*state_bytes)
         .map_err(|_| ErrorCode::UnableToLoadAccountLoader)?;
 


### PR DESCRIPTION
Follow-up to #122. protocol-v2-shadow `master` did the **drift→velocity rebrand** (#70): the `drift` crate is now `velocity` at `programs/velocity`, feature `drift-rs`→`velocity-rs`, IDL `drift.json`→`velocity.json`. This adapts swift to it.

## Changes
- `Cargo.toml`: consume the renamed crate via package-rename — `drift = { package = "velocity", path = "../protocol-v2-shadow/programs/velocity", features = ["velocity-rs", ...] }`. The `drift` alias keeps existing `drift::` code working.
- `src/util/local_sim.rs`: `DriftResult`→`VelocityResult`, `DriftAccounts`→`VelocityAccounts`.

## Notes
- `cargo check --all-targets` green.
- Pairs with drift-rs@next (`61edb8d`) and keep-rs@next (`f76a934`).
- `SHADOW_REF` stays `master` (now the velocity rebrand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)